### PR TITLE
Add foreground config option to prevent forking without using debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,8 +258,9 @@ Here are the global configuration keys:
 
 | Config Key | Default Value | Description |
 |------------|---------------|-------------|
-| `debug` | `false` | When set to `true`, will run directly on the console without forking a daemon process. |
-| `echo` | `false` | When set to `true` and combined with `debug`, will echo all log output to the console. |
+| `foreground` | `false` | When set to `true`, will run directly on the console without forking a daemon process. |
+| `debug` | `false` | When set to `true`, will run directly on the console without forking a daemon process and enable debug behavior. |
+| `echo` | `false` | When set to `true` and combined with `debug` or `foreground`, will echo all log output to the console. |
 | `color` | `false` | When set to `true` and combined with `echo`, all log columns will be colored in the console. |
 | `log_dir` | "." | Directory path where event log will be stored. |
 | `log_filename` | "event.log" | Event log filename, joined with `log_dir`. |

--- a/server.js
+++ b/server.js
@@ -76,6 +76,7 @@ module.exports = Class.create({
 			}
 		}
 		
+		this.foreground = this.config.get('foreground') || false;
 		this.debug = this.config.get('debug') || false;
 		this.echo = this.config.get('echo') || false;
 		this.color = this.config.get('color') || false;
@@ -109,8 +110,8 @@ module.exports = Class.create({
 		// allow components to hook post init and possibly interrupt startup
 		if (!this.earlyStartComponents()) return;
 		
-		// become a daemon unless in debug mode
-		if (!this.debug) {
+		// become a daemon unless in debug mode or foreground mode
+		if (!this.debug && !this.foreground) {
 			// pass node cli args down to forked daemon process
 			if (!process.env.__daemon) {
 				var cli_args = process.execArgv;


### PR DESCRIPTION
In Cronicle project when setting "debug" CLI option to prevent daemon forking to background it also triggers specific unwanted behaviors (Not being able to use Restart/Shutdown, not computing Stats, not running missed events...)

To use Cronicle in "production" mode without forking to background I think a dedicated option could be useful.

This would help running Cronicle in container environment such as Docker.